### PR TITLE
Rust 2018 fixes

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,6 +8,7 @@ repository = "https://github.com/whitequark/rust-vnc"
 homepage = "https://github.com/whitequark/rust-vnc"
 documentation = "https://whitequark.github.io/rust-vnc/vnc"
 description = "An implementation of VNC protocol, client state machine, a client and a proxy"
+edition = "2018"
 
 [features]
 apple-auth = ["num-bigint", "octavo", "rust-crypto"]

--- a/client/Cargo.toml
+++ b/client/Cargo.toml
@@ -7,6 +7,7 @@ readme = "../README.md"
 repository = "https://github.com/whitequark/rust-vnc"
 homepage = "https://github.com/whitequark/rust-vnc"
 description = "A VNC client"
+edition = "2018"
 
 [features]
 apple-auth = ["vnc/apple-auth"]
@@ -17,8 +18,8 @@ path = "main.rs"
 
 [dependencies]
 byteorder = "0.5"
-log = "0.3"
-env_logger = "0.3"
+log = "0.4"
+env_logger = "0.7"
 clap = "1.5"
 sdl2 = "0.13"
 x11 = "2.3"

--- a/client/main.rs
+++ b/client/main.rs
@@ -1,13 +1,15 @@
-extern crate env_logger;
+/*extern crate env_logger;
 #[macro_use] extern crate log;
 #[macro_use] extern crate clap;
 extern crate vnc;
 extern crate sdl2;
 extern crate x11;
-extern crate byteorder;
+extern crate byteorder;*/
+
+use log::{info, error, debug, warn};
 
 use std::io::{Result as IoResult, ErrorKind as IoErrorKind, Read, Write, Cursor};
-use clap::{Arg, App};
+use clap::{Arg, App, value_t};
 use sdl2::pixels::{Color, PixelMasks, PixelFormatEnum as SdlPixelFormat};
 use sdl2::rect::Rect as SdlRect;
 use byteorder::{NativeEndian, ReadBytesExt, WriteBytesExt};
@@ -93,7 +95,7 @@ fn mask_cursor(vnc_in_format: vnc::PixelFormat, in_pixels: Vec<u8>, mask_pixels:
 
     fn read_color<R: Read>(reader: &mut R, size: usize, masks: &PixelMasks) ->
             IoResult<Color> {
-        let packed = try!(reader.read_uint::<NativeEndian>(size));
+        let packed = reader.read_uint::<NativeEndian>(size)?;
         Ok(Color::RGB(
             ((packed as u32 & masks.rmask) >> masks.rmask.trailing_zeros()) as u8,
             ((packed as u32 & masks.gmask) >> masks.gmask.trailing_zeros()) as u8,
@@ -135,7 +137,7 @@ fn mask_cursor(vnc_in_format: vnc::PixelFormat, in_pixels: Vec<u8>, mask_pixels:
 }
 
 fn main() {
-    env_logger::init().unwrap();
+    env_logger::init();
 
     let matches = App::new("rvncclient")
         .about("VNC client")

--- a/client/main.rs
+++ b/client/main.rs
@@ -57,14 +57,14 @@ fn pixel_format_vnc_to_sdl(vnc_format: vnc::PixelFormat) -> Option<SdlPixelForma
     for format in &FORMAT_MAP {
         if format.1 == vnc_format { return Some(format.0) }
     }
-    return None
+    None
 }
 
 fn pixel_format_sdl_to_vnc(sdl_format: SdlPixelFormat) -> Option<vnc::PixelFormat> {
     for format in &FORMAT_MAP {
         if format.0 == sdl_format { return Some(format.1) }
     }
-    return None
+    None
 }
 
 fn mask_cursor(vnc_in_format: vnc::PixelFormat, in_pixels: Vec<u8>, mask_pixels: Vec<u8>) ->
@@ -190,14 +190,15 @@ fn main() {
             }
         };
 
+    #[allow(clippy::single_match)]
     let mut vnc =
         match vnc::Client::from_tcp_stream(stream, !exclusive, |methods| {
             debug!("available authentication methods: {:?}", methods);
             for method in methods {
                 match method {
-                    &vnc::client::AuthMethod::None =>
+                    vnc::client::AuthMethod::None =>
                         return Some(vnc::client::AuthChoice::None),
-                    &vnc::client::AuthMethod::Password => {
+                    vnc::client::AuthMethod::Password => {
                         return match password {
                             None => None,
                             Some(ref password) => {
@@ -210,7 +211,7 @@ fn main() {
                             }
                         }
                     },
-                    &vnc::client::AuthMethod::AppleRemoteDesktop =>
+                    vnc::client::AuthMethod::AppleRemoteDesktop =>
                         match (username, password) {
                             (Some(username), Some(password)) =>
                                 return Some(vnc::client::AuthChoice::AppleRemoteDesktop(
@@ -278,7 +279,7 @@ fn main() {
     let mut key_ctrl = false;
 
     renderer.clear();
-    vnc.request_update(vnc::Rect { left: 0, top: 0, width: width, height: height},
+    vnc.request_update(vnc::Rect { left: 0, top: 0, width, height },
                        false).unwrap();
 
     let mut incremental = true;
@@ -316,7 +317,7 @@ fn main() {
                         sdl_format.byte_size_of_pixels(vnc_rect.width as usize)).unwrap();
                     renderer.copy(&screen, Some(sdl_rect), Some(sdl_rect));
                     incremental |= vnc_rect == vnc::Rect { left: 0, top: 0,
-                                                           width: width, height: height };
+                                                           width, height };
                 },
                 Event::CopyPixels { src: vnc_src, dst: vnc_dst } => {
                     let sdl_src = SdlRect::new_unwrap(
@@ -382,6 +383,7 @@ fn main() {
             if sdl_timer.ticks() - ticks > FRAME_MS { continue 'running }
         }
 
+        #[allow(clippy::single_match)]
         match cursor_rect {
             Some(cursor_rect) =>
                 renderer.copy(&screen, Some(cursor_rect), Some(cursor_rect)),
@@ -431,6 +433,7 @@ fn main() {
 
             if view_only { continue }
 
+            #[allow(clippy::single_match)]
             match event {
                 Event::KeyDown { keycode: Some(keycode), .. } |
                 Event::KeyUp { keycode: Some(keycode), .. } => {
@@ -502,7 +505,7 @@ fn main() {
             vnc.poke_qemu().unwrap();
             qemu_next_update = sdl_timer.ticks() + qemu_network_rtt / 2;
         } else {
-            vnc.request_update(vnc::Rect { left: 0, top: 0, width: width, height: height},
+            vnc.request_update(vnc::Rect { left: 0, top: 0, width, height},
                                incremental).unwrap();
 
         }

--- a/client/main.rs
+++ b/client/main.rs
@@ -181,7 +181,6 @@ fn main() {
             }
         };
 
-    #[allow(clippy::single_match)]
     let mut vnc =
         match vnc::Client::from_tcp_stream(stream, !exclusive, |methods| {
             debug!("available authentication methods: {:?}", methods);
@@ -374,7 +373,6 @@ fn main() {
             if sdl_timer.ticks() - ticks > FRAME_MS { continue 'running }
         }
 
-        #[allow(clippy::single_match)]
         match cursor_rect {
             Some(cursor_rect) =>
                 renderer.copy(&screen, Some(cursor_rect), Some(cursor_rect)),
@@ -424,7 +422,6 @@ fn main() {
 
             if view_only { continue }
 
-            #[allow(clippy::single_match)]
             match event {
                 Event::KeyDown { keycode: Some(keycode), .. } |
                 Event::KeyUp { keycode: Some(keycode), .. } => {

--- a/client/main.rs
+++ b/client/main.rs
@@ -1,13 +1,4 @@
-/*extern crate env_logger;
-#[macro_use] extern crate log;
-#[macro_use] extern crate clap;
-extern crate vnc;
-extern crate sdl2;
-extern crate x11;
-extern crate byteorder;*/
-
 use log::{info, error, debug, warn};
-
 use std::io::{Result as IoResult, ErrorKind as IoErrorKind, Read, Write, Cursor};
 use clap::{Arg, App, value_t};
 use sdl2::pixels::{Color, PixelMasks, PixelFormatEnum as SdlPixelFormat};

--- a/proxy/Cargo.toml
+++ b/proxy/Cargo.toml
@@ -7,6 +7,7 @@ readme = "../README.md"
 repository = "https://github.com/whitequark/rust-vnc"
 homepage = "https://github.com/whitequark/rust-vnc"
 description = "A VNC proxy"
+edition = "2018"
 
 [features]
 apple-auth = ["vnc/apple-auth"]

--- a/src/client.rs
+++ b/src/client.rs
@@ -221,7 +221,6 @@ impl Client {
             }
         }
 
-        #[allow(clippy::single_match)]
         match auth_choice {
             AuthChoice::Password(mut password) => {
                 // Reverse the bits in every byte of password.
@@ -233,7 +232,6 @@ impl Client {
                 // I hate every single fucker involved in the chain of decisions that
                 // led to this authentication scheme, and doubly so because it is completely
                 // undocumented in what passes for the specification of the RFB protocol.
-                #[allow(clippy::needless_range_loop)]
                 for i in 0..8 {
                     let c = password[i];
                     let mut cs = 0u8;

--- a/src/client.rs
+++ b/src/client.rs
@@ -11,23 +11,21 @@ use crate::security::des;
 use security::apple_auth;
 
 #[derive(Debug)]
+#[non_exhaustive]
 pub enum AuthMethod {
     None,
     Password,
     AppleRemoteDesktop,
     /* more to come */
-    #[doc(hidden)]
-    __Nonexhaustive,
 }
 
 #[derive(Debug)]
+#[non_exhaustive]
 pub enum AuthChoice {
     None,
     Password([u8; 8]),
     AppleRemoteDesktop(String, String),
     /* more to come */
-    #[doc(hidden)]
-    __Nonexhaustive,
 }
 
 #[derive(Debug)]
@@ -72,7 +70,7 @@ impl Event {
             match packet {
                 protocol::S2C::SetColourMapEntries { first_colour, colours } => {
                     send!(tx_events, Event::SetColourMap {
-                        first_colour: first_colour, colours: colours
+                        first_colour, colours,
                     })
                 },
                 protocol::S2C::FramebufferUpdate { count } => {
@@ -105,7 +103,7 @@ impl Event {
                                     width:  rectangle.width,
                                     height: rectangle.height
                                 };
-                                send!(tx_events, Event::CopyPixels { src: src, dst: dst })
+                                send!(tx_events, Event::CopyPixels { src, dst })
                             },
                             protocol::Encoding::Zrle => {
                                 let length = stream.read_u32::<BigEndian>()?;
@@ -130,8 +128,8 @@ impl Event {
                                 send!(tx_events, Event::SetCursor {
                                     size:      (rectangle.width, rectangle.height),
                                     hotspot:   (rectangle.x_position, rectangle.y_position),
-                                    pixels:    pixels,
-                                    mask_bits: mask_bits
+                                    pixels,
+                                    mask_bits,
                                 })
                             },
                             protocol::Encoding::DesktopSize => {
@@ -217,7 +215,6 @@ impl Client {
                     AuthChoice::None => protocol::SecurityType::None,
                     AuthChoice::Password(_) => protocol::SecurityType::VncAuthentication,
                     AuthChoice::AppleRemoteDesktop(_, _) => protocol::SecurityType::AppleRemoteDesktop,
-                    AuthChoice::__Nonexhaustive => unreachable!()
                 };
                 debug!("-> SecurityType::{:?}", used_security_type);
                 protocol::SecurityType::write_to(&used_security_type, &mut stream)?;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -47,24 +47,13 @@ impl std::fmt::Display for Error {
                 write!(f, "server error: {}", descr),
             &Error::AuthenticationFailure(ref descr) =>
                 write!(f, "authentication failure: {}", descr),
-            _ => f.write_str(std::error::Error::description(self))
+            _ => f.write_str(&self.to_string())
         }
     }
 }
 
 impl std::error::Error for Error {
-    fn description(&self) -> &str {
-        match self {
-            &Error::Io(ref inner) => inner.description(),
-            &Error::Unexpected(_) => "unexpected value",
-            &Error::Server(_) => "server error",
-            &Error::AuthenticationUnavailable => "authentication unavailable",
-            &Error::AuthenticationFailure(_) => "authentication failure",
-            &Error::Disconnected => "peer disconnected",
-        }
-    }
-
-    fn cause(&self) -> Option<&std::error::Error> {
+    fn cause(&self) -> Option<&dyn std::error::Error> {
         match self {
             &Error::Io(ref inner) => Some(inner),
             _ => None

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -40,12 +40,12 @@ pub enum Error {
 impl std::fmt::Display for Error {
     fn fmt(&self, f: &mut std::fmt::Formatter) -> std::result::Result<(), std::fmt::Error> {
         match self {
-            &Error::Io(ref inner) => inner.fmt(f),
-            &Error::Unexpected(ref descr) =>
+            Error::Io(ref inner) => inner.fmt(f),
+            Error::Unexpected(ref descr) =>
                 write!(f, "unexpected {}", descr),
-            &Error::Server(ref descr) =>
+            Error::Server(ref descr) =>
                 write!(f, "server error: {}", descr),
-            &Error::AuthenticationFailure(ref descr) =>
+            Error::AuthenticationFailure(ref descr) =>
                 write!(f, "authentication failure: {}", descr),
             _ => f.write_str(&self.to_string())
         }
@@ -55,7 +55,7 @@ impl std::fmt::Display for Error {
 impl std::error::Error for Error {
     fn cause(&self) -> Option<&dyn std::error::Error> {
         match self {
-            &Error::Io(ref inner) => Some(inner),
+            Error::Io(ref inner) => Some(inner),
             _ => None
         }
     }

--- a/src/proxy.rs
+++ b/src/proxy.rs
@@ -1,8 +1,8 @@
 use std::io::{Read, Write, Cursor};
 use std::net::{TcpStream, Shutdown};
 use std::thread;
-use ::{Error, Result};
-use protocol::{self, Message};
+use crate::{Error, Result};
+use crate::protocol::{self, Message};
 
 pub struct Proxy {
     c2s_thread: thread::JoinHandle<Result<()>>,
@@ -12,13 +12,13 @@ pub struct Proxy {
 impl Proxy {
     pub fn from_tcp_streams(mut server_stream: TcpStream, mut client_stream: TcpStream) ->
             Result<Proxy> {
-        let server_version = try!(protocol::Version::read_from(&mut server_stream));
+        let server_version = protocol::Version::read_from(&mut server_stream)?;
         debug!("c<-s {:?}", server_version);
-        try!(protocol::Version::write_to(&server_version, &mut client_stream));
+        protocol::Version::write_to(&server_version, &mut client_stream)?;
 
-        let client_version = try!(protocol::Version::read_from(&mut client_stream));
+        let client_version = protocol::Version::read_from(&mut client_stream)?;
         debug!("c->s {:?}", client_version);
-        try!(protocol::Version::write_to(&client_version, &mut server_stream));
+        protocol::Version::write_to(&client_version, &mut server_stream)?;
 
         fn security_type_supported(security_type: &protocol::SecurityType) -> bool {
             match security_type {
@@ -32,7 +32,7 @@ impl Proxy {
 
         let security_types = match client_version {
             protocol::Version::Rfb33 => {
-                let mut security_type = try!(protocol::SecurityType::read_from(&mut server_stream));
+                let mut security_type = protocol::SecurityType::read_from(&mut server_stream)?;
                 debug!("!<-s SecurityType::{:?}", security_type);
 
                 // Filter out security types we can't handle
@@ -41,7 +41,7 @@ impl Proxy {
                 }
 
                 debug!("c<-! SecurityType::{:?}", security_type);
-                try!(protocol::SecurityType::write_to(&security_type, &mut client_stream));
+                protocol::SecurityType::write_to(&security_type, &mut client_stream)?;
 
                 if security_type == protocol::SecurityType::Invalid {
                     vec![]
@@ -51,23 +51,23 @@ impl Proxy {
             },
             _ => {
                 let mut security_types =
-                    try!(protocol::SecurityTypes::read_from(&mut server_stream));
+                    protocol::SecurityTypes::read_from(&mut server_stream)?;
                 debug!("!<-s {:?}", security_types);
 
                 // Filter out security types we can't handle
                 security_types.0.retain(security_type_supported);
 
                 debug!("c<-! {:?}", security_types);
-                try!(protocol::SecurityTypes::write_to(&security_types, &mut client_stream));
+                protocol::SecurityTypes::write_to(&security_types, &mut client_stream)?;
 
                 security_types.0
             }
         };
 
         if security_types.len() == 0 {
-            let reason = try!(String::read_from(&mut server_stream));
+            let reason = String::read_from(&mut server_stream)?;
             debug!("c<-s {:?}", reason);
-            try!(String::write_to(&reason, &mut client_stream));
+            String::write_to(&reason, &mut client_stream)?;
 
             return Err(Error::Server(reason))
         }
@@ -76,9 +76,9 @@ impl Proxy {
             protocol::Version::Rfb33 => security_types[0],
             _ => {
                 let used_security_type =
-                    try!(protocol::SecurityType::read_from(&mut client_stream));
+                    protocol::SecurityType::read_from(&mut client_stream)?;
                 debug!("c->s SecurityType::{:?}", used_security_type);
-                try!(protocol::SecurityType::write_to(&used_security_type, &mut server_stream));
+                protocol::SecurityType::write_to(&used_security_type, &mut server_stream)?;
 
                 used_security_type
             }
@@ -93,31 +93,31 @@ impl Proxy {
         }
 
         if !skip_security_result {
-            let security_result = try!(protocol::SecurityResult::read_from(&mut server_stream));
+            let security_result = protocol::SecurityResult::read_from(&mut server_stream)?;
             debug!("c<-s SecurityResult::{:?}", security_result);
-            try!(protocol::SecurityResult::write_to(&security_result, &mut client_stream));
+            protocol::SecurityResult::write_to(&security_result, &mut client_stream)?;
 
             if security_result == protocol::SecurityResult::Failed {
                 match client_version {
                     protocol::Version::Rfb33 | protocol::Version::Rfb37 =>
                         return Err(Error::AuthenticationFailure(String::from(""))),
                     protocol::Version::Rfb38 => {
-                        let reason = try!(String::read_from(&mut server_stream));
+                        let reason = String::read_from(&mut server_stream)?;
                         debug!("c<-s {:?}", reason);
-                        try!(String::write_to(&reason, &mut client_stream));
+                        String::write_to(&reason, &mut client_stream)?;
                         return Err(Error::AuthenticationFailure(reason))
                     }
                 }
             }
         }
 
-        let client_init = try!(protocol::ClientInit::read_from(&mut client_stream));
+        let client_init = protocol::ClientInit::read_from(&mut client_stream)?;
         debug!("c->s {:?}", client_init);
-        try!(protocol::ClientInit::write_to(&client_init, &mut server_stream));
+        protocol::ClientInit::write_to(&client_init, &mut server_stream)?;
 
-        let server_init = try!(protocol::ServerInit::read_from(&mut server_stream));
+        let server_init = protocol::ServerInit::read_from(&mut server_stream)?;
         debug!("c<-s {:?}", server_init);
-        try!(protocol::ServerInit::write_to(&server_init, &mut client_stream));
+        protocol::ServerInit::write_to(&server_init, &mut client_stream)?;
 
         let (mut c2s_server_stream, mut c2s_client_stream) =
             (server_stream.try_clone().unwrap(), client_stream.try_clone().unwrap());
@@ -141,7 +141,7 @@ impl Proxy {
             }
 
             loop {
-                let mut message = try!(protocol::C2S::read_from(client_stream));
+                let mut message = protocol::C2S::read_from(client_stream)?;
                 match message {
                     protocol::C2S::SetEncodings(ref mut encodings) => {
                         debug!("c->! SetEncodings({:?})", encodings);
@@ -159,7 +159,7 @@ impl Proxy {
                     },
                     ref message => debug!("c->s {:?}", message)
                 }
-                try!(protocol::C2S::write_to(&message, server_stream))
+                protocol::C2S::write_to(&message, server_stream)?
             }
         }
 
@@ -170,48 +170,48 @@ impl Proxy {
             loop {
                 let mut buffer_stream = Cursor::new(Vec::new());
 
-                let message = try!(protocol::S2C::read_from(server_stream));
+                let message = protocol::S2C::read_from(server_stream)?;
                 debug!("c<-s {:?}", message);
-                try!(protocol::S2C::write_to(&message, &mut buffer_stream));
+                protocol::S2C::write_to(&message, &mut buffer_stream)?;
 
                 match message {
                     protocol::S2C::FramebufferUpdate { count } => {
                         for _ in 0..count {
-                            let rectangle = try!(protocol::Rectangle::read_from(server_stream));
+                            let rectangle = protocol::Rectangle::read_from(server_stream)?;
                             debug!("c<-s {:?}", rectangle);
-                            try!(protocol::Rectangle::write_to(&rectangle, &mut buffer_stream));
+                            protocol::Rectangle::write_to(&rectangle, &mut buffer_stream)?;
 
                             match rectangle.encoding {
                                 protocol::Encoding::Raw => {
                                     let mut pixels = vec![0; (rectangle.width as usize) *
                                                              (rectangle.height as usize) *
                                                              (format.bits_per_pixel as usize / 8)];
-                                    try!(server_stream.read_exact(&mut pixels));
+                                    server_stream.read_exact(&mut pixels)?;
                                     debug!("c<-s ...raw pixels");
-                                    try!(buffer_stream.write_all(&pixels));
+                                    buffer_stream.write_all(&pixels)?;
                                 },
                                 protocol::Encoding::CopyRect => {
                                     let copy_rect =
-                                        try!(protocol::CopyRect::read_from(server_stream));
+                                        protocol::CopyRect::read_from(server_stream)?;
                                     debug!("c<-s {:?}", copy_rect);
-                                    try!(protocol::CopyRect::write_to(&copy_rect,
-                                                                      &mut buffer_stream));
+                                    protocol::CopyRect::write_to(&copy_rect,
+                                                                      &mut buffer_stream)?;
                                 },
                                 protocol::Encoding::Zrle => {
-                                    let zrle = try!(Vec::<u8>::read_from(server_stream));
+                                    let zrle = Vec::<u8>::read_from(server_stream)?;
                                     debug!("c<-s ...ZRLE pixels");
-                                    try!(Vec::<u8>::write_to(&zrle, &mut buffer_stream));
+                                    Vec::<u8>::write_to(&zrle, &mut buffer_stream)?;
                                 }
                                 protocol::Encoding::Cursor => {
                                     let mut pixels    = vec![0; (rectangle.width as usize) *
                                                                 (rectangle.height as usize) *
                                                                 (format.bits_per_pixel as usize / 8)];
-                                    try!(server_stream.read_exact(&mut pixels));
-                                    try!(buffer_stream.write_all(&pixels));
+                                    server_stream.read_exact(&mut pixels)?;
+                                    buffer_stream.write_all(&pixels)?;
                                     let mut mask_bits = vec![0; ((rectangle.width as usize + 7) / 8) *
                                                                 (rectangle.height as usize)];
-                                    try!(server_stream.read_exact(&mut mask_bits));
-                                    try!(buffer_stream.write_all(&mask_bits));
+                                    server_stream.read_exact(&mut mask_bits)?;
+                                    buffer_stream.write_all(&mask_bits)?;
                                 },
                                 protocol::Encoding::DesktopSize => (),
                                 _ => return Err(Error::Unexpected("encoding"))
@@ -222,7 +222,7 @@ impl Proxy {
                 }
 
                 let buffer = buffer_stream.into_inner();
-                try!(client_stream.write_all(&buffer));
+                client_stream.write_all(&buffer)?;
             }
         }
 

--- a/src/proxy.rs
+++ b/src/proxy.rs
@@ -174,7 +174,6 @@ impl Proxy {
                 debug!("c<-s {:?}", message);
                 protocol::S2C::write_to(&message, &mut buffer_stream)?;
 
-                #[allow(clippy::single_match)]
                 match message {
                     protocol::S2C::FramebufferUpdate { count } => {
                         for _ in 0..count {

--- a/src/proxy.rs
+++ b/src/proxy.rs
@@ -64,7 +64,7 @@ impl Proxy {
             }
         };
 
-        if security_types.len() == 0 {
+        if security_types.is_empty() {
             let reason = String::read_from(&mut server_stream)?;
             debug!("c<-s {:?}", reason);
             String::write_to(&reason, &mut client_stream)?;
@@ -174,6 +174,7 @@ impl Proxy {
                 debug!("c<-s {:?}", message);
                 protocol::S2C::write_to(&message, &mut buffer_stream)?;
 
+                #[allow(clippy::single_match)]
                 match message {
                     protocol::S2C::FramebufferUpdate { count } => {
                         for _ in 0..count {

--- a/src/security/des.rs
+++ b/src/security/des.rs
@@ -47,7 +47,7 @@ fn compute_subkeys(key: u64) -> Vec<u64> {
     let mut subkeys = vec![k0];
 
     for shift_count in &table {
-        let last_key = subkeys.last().unwrap().clone();
+        let last_key = subkeys.last().unwrap();
         let last_ci = last_key & 0xFFFFFFF000000000;
         let last_di = last_key << HALF_KEY_SIZE;
         let (ci, di) = circular_left_shift(last_ci, last_di, *shift_count);
@@ -278,12 +278,10 @@ fn s(box_id: usize, block: u64) -> u64 {
 /// Swap bits using a table.
 fn swap_bits(key: u64, table: &[u64]) -> u64 {
     let mut result = 0;
-    let mut pos = 0;
 
-    for index in table.iter() {
+    for (pos, index) in table.iter().enumerate() {
         let bit = (key << (index - 1)) & FIRST_BIT;
         result |= bit >> pos;
-        pos += 1;
     }
 
     result
@@ -291,7 +289,7 @@ fn swap_bits(key: u64, table: &[u64]) -> u64 {
 
 /// Convert a slice to a `Key`.
 fn to_key(slice: &[u8]) -> Key {
-    let mut vec: Vec<u8> = slice.iter().cloned().collect();
+    let mut vec: Vec<u8> = slice.to_vec();
     let mut key = [0; 8];
     let diff = key.len() - vec.len();
     if diff > 0 {

--- a/src/zrle.rs
+++ b/src/zrle.rs
@@ -140,7 +140,7 @@ impl Decoder {
             (format.red_max   as u32) << format.red_shift   |
             (format.green_max as u32) << format.green_shift |
             (format.blue_max  as u32) << format.blue_shift;
-        #[allow(clippy::verbose_bit_mask)]
+
         let (compressed_bpp, pad_pixel) =
             if format.bits_per_pixel == 32 && format.true_colour && format.depth <= 24 {
                 if pixel_mask & 0x000000ff == 0 {


### PR DESCRIPTION
I've updated the code to 2018 edition for the library and the two crates. I tested the client crate and it still works, but when I tried the proxy I got `thread '<unnamed>' panicked at 'proxying SetPixelFormat is not implemented!', src/proxy.rs:158:25`.

The only dependencies I updated were log and env_logger to get it to compile, so there are still some outdated deps.

Clippy warnings have either been addressed or explicitly ignored